### PR TITLE
Remove no-longer-needed changes from d1c74cb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ OPTS_PDFTEX_wasm         = CC="$(CCSKIP_TEX_wasm)      emcc $(CFLAGS_PDFTEX) $(C
 OPTS_XDVIPDFMX_wasm      = CC="emcc $(CFLAGS_XDVIPDFMX)    $(CFLAGS_OPT_wasm)" CXX="em++          $(CFLAGS_XDVIPDFMX)    $(CFLAGS_OPT_wasm)"
 OPTS_XDVIPDFMX_native    = -e CFLAGS="$(CFLAGS_TEXLIVE_native) $(CFLAGS_XDVIPDFMX)    $(CFLAGS_OPT_native)" -e CPPFLAGS="$(CFLAGS_TEXLIVE_native) $(CFLAGS_XDVIPDFMX)    $(CFLAGS_OPT_native)"
 OPTS_BIBTEX_native       = -e CFLAGS="$(CFLAGS_BIBTEX)         $(CFLAGS_OPT_native)" -e CXXFLAGS="$(CFLAGS_BIBTEX)       $(CFLAGS_OPT_native)"
-OPTS_XETEX_native        = CC="$(CC_native) $(CFLAGS_XETEX)    $(CFLAGS_OPT_native) $(addprefix $(abspath build/native)/, $(OBJ_DEPS_XETEX))" CXX="$(CXX_native) $(CFLAGS_XETEX)  $(CFLAGS_OPT_native) $(addprefix $(abspath build/native)/, $(OBJ_DEPS_XETEX))"
+OPTS_XETEX_native        = CC="$(CC_native) $(CFLAGS_XETEX)    $(CFLAGS_OPT_native)" CXX="$(CXX_native) $(CFLAGS_XETEX)  $(CFLAGS_OPT_native)"
 OPTS_PDFTEX_native       = CC="$(CC_native) $(CFLAGS_PDFTEX)   $(CFLAGS_OPT_native)" CXX="$(CXX_native) $(CFLAGS_PDFTEX) $(CFLAGS_OPT_native)"
 OPTS_LUAHBTEX_native     = CC="$(CC_native) $(CFLAGS_LUAHBTEX) $(CFLAGS_OPT_native)" CXX="$(CXX_native) $(CFLAGS_LUAHBTEX) $(CFLAGS_OPT_native)"
 OPTS_LUAHBTEX_wasm       = CC="$(CCSKIP_TEX_wasm) emcc $(CFLAGS_LUAHBTEX)   $(CFLAGS_OPT_wasm)" CXX="$(CCSKIP_TEX_wasm) em++ $(CFLAGS_LUAHBTEX)       $(CFLAGS_OPT_wasm)"


### PR DESCRIPTION
d1c74cb introduced a trick to add `*.a` files to `CC/CXX` unconditionally, which results in broken compilation commands that look like this:
```
CC [...] [...]/build/native/fontconfig/src/.libs/libfontconfig.a [...]/build/native/texlive/libs/icu/icu-build/lib/libicuuc.a [...]/build/native/texlive/libs/icu/icu-build/lib/libicudata.a [...] kps.o [...] -c -o kps.o [...]/source/texlive/texk/web2c/web2c/kps.c
```

Here, we request a `X.c` -> `X.o` compilation with `-c`, but also include `*.a` files in the command line, which won't be used at all.

Regular `musl-gcc` or `x86_64-unknown-cosmo-cc` handle this fine but print a warning:
```
[...]/build/native/fontconfig/src/.libs/libfontconfig.a: linker input file unused because linking not done
``` 

`cosmocc`, however, refuses to run the weird command:
```
cosmocc: fatal error: cannot specify '-o' with '-c', or '-E' with multiple files
```

It turns out that the trick is no longer even needed: the CI [says](https://github.com/busytex/busytex/actions/runs/7864918312/job/21457254723) the native build compiles and links just fine without it.

This PR reverts the trick, which gets rids of warnings during the `musl` build, and allows the Cosmopolitan build to pass.