### PR TITLE
Make busytex cross-platform

### DIFF
--- a/build_cosmo.sh
+++ b/build_cosmo.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This script is provided for convenience in case
+# you want to build a Cosmopolitan binary locally.
+# It is not used when preparing releases.
+#
+# Run it as: ./build_cosmo.sh PATH_TO_COSMOCC_TOOLCHAIN
+
+set -eu
+
+COSMODIR=$1/bin
+
+CC="${COSMODIR}/cosmocc" \
+CXX="${COSMODIR}/cosmoc++" \
+AR="${COSMODIR}/cosmoar" \
+INSTALL="${COSMODIR}/cosmoinstall" \
+make native

--- a/cosmo_getpass.h
+++ b/cosmo_getpass.h
@@ -1,0 +1,12 @@
+/*
+ * An implementation of the deprecated `getpass()` function for Cosmopolitan Libc.
+ * It is included directly in `texlive/texk/dvipdfm-x/dvipdfmx.c`.
+ */
+#ifdef __COSMOPOLITAN__
+#include <stdio.h>
+#include <stdlib.h>
+static char* getpass(const char* prompt) {
+  fprintf(stderr, "Password encryption is not supported\n");
+  exit(1);
+}
+#endif

--- a/example/example.bat
+++ b/example/example.bat
@@ -1,0 +1,35 @@
+@echo off
+set DIST=%cd%\dist-native
+set XELATEXFMT=%DIST%\xelatex.fmt
+set PDFLATEXFMT=%DIST%\pdflatex.fmt
+set LUAHBLATEXFMT=%DIST%\luahblatex.fmt
+set LUALATEXFMT=%DIST%\lualatex.fmt
+set BUSYTEX=%DIST%\busytex.com
+
+set TEXMFDIST=%DIST%\texlive\texmf-dist
+set TEXMFVAR=%DIST%\texlive\texmf-dist\texmf-var
+set TEXMFCNF=%TEXMFDIST%\web2c
+set FONTCONFIG_PATH=%DIST%
+
+cd example
+
+%BUSYTEX% xelatex --no-shell-escape --interaction nonstopmode --halt-on-error --no-pdf --fmt %XELATEXFMT% example.tex
+%BUSYTEX% bibtex8 --8bit example.aux
+%BUSYTEX% xelatex --no-shell-escape --interaction nonstopmode --halt-on-error --no-pdf --fmt %XELATEXFMT% example.tex
+%BUSYTEX% xelatex --no-shell-escape --interaction nonstopmode --halt-on-error --no-pdf --fmt %XELATEXFMT% example.tex
+%BUSYTEX% xdvipdfmx -o example_xelatex.pdf example.xdv
+erase example.aux
+
+%BUSYTEX% pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %PDFLATEXFMT% example.tex
+%BUSYTEX% bibtex8 --8bit example.aux
+%BUSYTEX% pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %PDFLATEXFMT% example.tex
+%BUSYTEX% pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %PDFLATEXFMT% example.tex
+move example.pdf example_pdflatex.pdf
+erase example.aux
+
+%BUSYTEX% luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %LUAHBLATEXFMT% --nosocket example.tex
+%BUSYTEX% bibtex8 --8bit example.aux
+%BUSYTEX% luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %LUAHBLATEXFMT% --nosocket example.tex
+%BUSYTEX% luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt %LUAHBLATEXFMT% --nosocket example.tex
+move example.pdf example_luahblatex.pdf
+erase example.aux

--- a/example/example.sh
+++ b/example/example.sh
@@ -21,23 +21,16 @@ $BUSYTEX xelatex --no-shell-escape --interaction nonstopmode --halt-on-error --n
 $BUSYTEX xdvipdfmx -o example_xelatex.pdf example.xdv
 rm example.aux
 
-#$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
-#$BUSYTEX bibtex8 --8bit example.aux
-#$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
-#$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
-#mv example.pdf example_pdflatex.pdf
-#rm example.aux
+$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
+$BUSYTEX bibtex8 --8bit example.aux
+$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
+$BUSYTEX pdflatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $PDFLATEXFMT example.tex
+mv example.pdf example_pdflatex.pdf
+rm example.aux
 
-#$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex 
-#$BUSYTEX bibtex8 --8bit example.aux
-#$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex 
-#$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex 
-#mv example.pdf example_luahblatex.pdf 
-#rm example.aux 
-
-#$BUSYTEX lualatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUALATEXFMT --nosocket example.tex 
-#$BUSYTEX bibtex8 --8bit example.aux
-#$BUSYTEX lualatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUALATEXFMT --nosocket example.tex 
-#$BUSYTEX lualatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUALATEXFMT --nosocket example.tex 
-#mv example.pdf example_lualatex.pdf 
-#rm example.aux 
+$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex
+$BUSYTEX bibtex8 --8bit example.aux
+$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex
+$BUSYTEX luahblatex --no-shell-escape --interaction nonstopmode --halt-on-error --output-format=pdf --fmt $LUAHBLATEXFMT --nosocket example.tex
+mv example.pdf example_luahblatex.pdf
+rm example.aux


### PR DESCRIPTION
This PR modifies the native build to support being built with [Cosmopolitan](https://github.com/jart/cosmopolitan). The resulting binary will still be statically linked, but it will be an [APE](https://justine.lol/ape.html) instead of ELF, so it can run unmodified on pretty much any desktop system.

The current Linux-only native build still builds and works exactly as it did before.

The CI workflow for building a Cosmo release is [already on main](https://github.com/busytex/busytex/blob/main/.github/workflows/build-cosmo.yml). Instead of multiple unrelated files from the native/WASM builds, it produces a single zip file with `texlive-basic` bundled. When unpacked, it can be used directly to compile basic TeX files.

Using that zip, I checked that `example/example.sh` works with:
  * an x86_64 laptop running Fedora Linux 39
  * the same x86_64 machine running Windows 11 Pro
  * an aarch64 machine running macOS Sonoma

Some other random notes:
  * I tried my best to document all workarounds/patches for the Cosmopolitan build with comments in the `Makefile`. Please let me know if anything is missing.
  * An `example.bat` was added along with `example.sh`, which does exactly the same thing, but for Windows.
  * I modified both example scripts to generate multiple PDFs with different TeX versions (only one of them was enabled before).